### PR TITLE
Fix HTML link formatting, WhatsApp button placement, room photo display, and add Instagram link

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -1,13 +1,22 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Contacto – Casa Rubia</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-VoBafk3xtQpFx9y4SULaPnKWPGtCtLS4ol6st2MUgSlww7gfGL4JyC7oHEI6CVJIq+57etZ5Cs2hcNUAzqX6cA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <link rel="stylesheet" href="style.css">
+  <link
+    href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    integrity="sha512-VoBafk3xtQpFx9y4SULaPnKWPGtCtLS4ol6st2MUgSlww7gfGL4JyC7oHEI6CVJIq+57etZ5Cs2hcNUAzqX6cA=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <header>
@@ -26,7 +35,7 @@
     <h2 class="section-title">Contacto</h2>
     <div style="max-width: var(--max-width); margin: 0 auto; display: flex; flex-wrap: wrap; gap: 2rem;">
       <div style="flex: 1 1 300px;">
-        <p>Estamos encantados de responder a tus preguntas, escuchar tus comentarios y ayudarte a planificar tu estancia en Casa&nbsp;Rubia. Puedes escribirnos utilizando el formulario a continuación o comunicarte por teléfono o correo electrónico.</p>
+        <p>Estamos encantados de responder tus preguntas, escuchar tus comentarios y ayudarte a planificar tu estadía en Casa&nbsp;Rubia. Escríbenos mediante el formulario o comunícate por teléfono o correo electrónico.</p>
         <ul style="list-style: none; padding: 0;">
           <li><strong>Dirección:</strong> Calle&nbsp;20&nbsp;#&nbsp;4‑04, Taganga</li>
           <li><strong>Teléfono:</strong> +57&nbsp;304&nbsp;671&nbsp;7881</li>
@@ -70,9 +79,13 @@
       <div class="footer-section">
         <h4>Síguenos</h4>
         <div class="social-icons">
-          <a href="#" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a>
-          <a href="#" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
-          <a href="#" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
+          <a
+            href="https://www.instagram.com/casarubiat/"
+            target="_blank"
+            aria-label="Instagram"
+          >
+            <img src="images/instagram.svg" alt="Instagram Casa Rubia" />
+          </a>
         </div>
       </div>
     </div>
@@ -80,5 +93,15 @@
   </footer>
 
   <script src="script.js"></script>
+  <div class="whatsapp-container">
+    <a
+      href="https://wa.me/573046717881"
+      target="_blank"
+      class="whatsapp-button"
+    >
+      <img src="images/WhatsApp.svg" alt="WhatsApp" />
+      <span class="tooltip">¿En qué te podemos ayudar?</span>
+    </a>
+  </div>
 </body>
 </html>

--- a/images/instagram.svg
+++ b/images/instagram.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="iso-8859-1"?>
+<!-- Generator: Adobe Illustrator 19.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 512 512" style="enable-background:new 0 0 512 512;" xml:space="preserve">
+<linearGradient id="SVGID_1_" gradientUnits="userSpaceOnUse" x1="-46.0041" y1="634.1208" x2="-32.9334" y2="647.1917" gradientTransform="matrix(32 0 0 -32 1519 20757)">
+	<stop  offset="0" style="stop-color:#FFC107"/>
+	<stop  offset="0.507" style="stop-color:#F44336"/>
+	<stop  offset="0.99" style="stop-color:#9C27B0"/>
+</linearGradient>
+<path style="fill:url(#SVGID_1_);" d="M352,0H160C71.648,0,0,71.648,0,160v192c0,88.352,71.648,160,160,160h192
+	c88.352,0,160-71.648,160-160V160C512,71.648,440.352,0,352,0z M464,352c0,61.76-50.24,112-112,112H160c-61.76,0-112-50.24-112-112
+	V160C48,98.24,98.24,48,160,48h192c61.76,0,112,50.24,112,112V352z"/>
+<linearGradient id="SVGID_2_" gradientUnits="userSpaceOnUse" x1="-42.2971" y1="637.8279" x2="-36.6404" y2="643.4846" gradientTransform="matrix(32 0 0 -32 1519 20757)">
+	<stop  offset="0" style="stop-color:#FFC107"/>
+	<stop  offset="0.507" style="stop-color:#F44336"/>
+	<stop  offset="0.99" style="stop-color:#9C27B0"/>
+</linearGradient>
+<path style="fill:url(#SVGID_2_);" d="M256,128c-70.688,0-128,57.312-128,128s57.312,128,128,128s128-57.312,128-128
+	S326.688,128,256,128z M256,336c-44.096,0-80-35.904-80-80c0-44.128,35.904-80,80-80s80,35.872,80,80
+	C336,300.096,300.096,336,256,336z"/>
+<linearGradient id="SVGID_3_" gradientUnits="userSpaceOnUse" x1="-35.5456" y1="644.5793" x2="-34.7919" y2="645.3331" gradientTransform="matrix(32 0 0 -32 1519 20757)">
+	<stop  offset="0" style="stop-color:#FFC107"/>
+	<stop  offset="0.507" style="stop-color:#F44336"/>
+	<stop  offset="0.99" style="stop-color:#9C27B0"/>
+</linearGradient>
+<circle style="fill:url(#SVGID_3_);" cx="393.6" cy="118.4" r="17.056"/>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -56,10 +56,9 @@
             Casa&nbsp;Rubia es un acogedor hotel familiar ubicado en Taganga, un
             pequeño pueblo pesquero a
             <strong>5&nbsp;km al norte de Santa Marta</strong> en la costa
-            Caribeña【903109919020372†L36-L37】. Rodeados de montañas desérticas
-            y de un mar rebosante de peces y corales【903109919020372†L86-L89】,
-            nuestros huéspedes disfrutan de una combinación única de naturaleza
-            y tranquilidad.
+            caribeña. Rodeados de montañas desérticas y de un mar rebosante de
+            peces y corales, nuestros huéspedes disfrutan de una combinación
+            única de naturaleza y tranquilidad.
           </p>
           <p>
             El hotel dispone de 12 habitaciones: seis equipadas con ventilador y
@@ -69,10 +68,9 @@
           </p>
           <p>
             Debido a las particularidades de la región, el suministro de agua se
-            realiza frecuentemente mediante camiones
-            cisterna【903109919020372†L41-L44】. Trabajamos con conciencia
-            ecológica para garantizar un uso responsable de los recursos y
-            ofrecerte una estadía confortable.
+            realiza frecuentemente mediante camiones cisterna. Trabajamos con
+            conciencia ecológica para garantizar un uso responsable de los
+            recursos y ofrecerte una estadía confortable.
           </p>
         </div>
         <div class="about-image">
@@ -224,13 +222,13 @@
         <div class="footer-section">
           <h4>Síguenos</h4>
           <div class="social-icons">
-            <a href="#" aria-label="Facebook"
-              ><i class="fab fa-facebook-f"></i
-            ></a>
-            <a href="#" aria-label="Instagram"
-              ><i class="fab fa-instagram"></i
-            ></a>
-            <a href="#" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
+            <a
+              href="https://www.instagram.com/casarubiat/"
+              target="_blank"
+              aria-label="Instagram"
+            >
+              <img src="images/instagram.svg" alt="Instagram Casa Rubia" />
+            </a>
           </div>
         </div>
       </div>
@@ -241,16 +239,16 @@
 
     <!-- Scripts -->
     <script src="script.js"></script>
+    <!-- BOTÓN WHATSAPP -->
+    <div class="whatsapp-container">
+      <a
+        href="https://wa.me/573046717881"
+        target="_blank"
+        class="whatsapp-button"
+      >
+        <img src="images/WhatsApp.svg" alt="WhatsApp" />
+        <span class="tooltip">¿En qué te podemos ayudar?</span>
+      </a>
+    </div>
   </body>
-  <!-- BOTÓN WHATSAPP -->
-  <div class="whatsapp-container">
-    <a
-      href="https://wa.me/573046717881"
-      target="_blank"
-      class="whatsapp-button"
-    >
-      <img src="images/WhatsApp.svg" alt="WhatsApp" />
-      <span class="tooltip">¿En qué te podemos ayudar?</span>
-    </a>
-  </div>
 </html>

--- a/rooms.html
+++ b/rooms.html
@@ -1,13 +1,22 @@
 <!DOCTYPE html>
 <html lang="es">
 <head>
-  <meta charset="UTF-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Habitaciones – Casa Rubia</title>
-  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha512-VoBafk3xtQpFx9y4SULaPnKWPGtCtLS4ol6st2MUgSlww7gfGL4JyC7oHEI6CVJIq+57etZ5Cs2hcNUAzqX6cA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-  <link rel="stylesheet" href="style.css">
+  <link
+    href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Open+Sans:wght@400;600&display=swap"
+    rel="stylesheet"
+  />
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+    integrity="sha512-VoBafk3xtQpFx9y4SULaPnKWPGtCtLS4ol6st2MUgSlww7gfGL4JyC7oHEI6CVJIq+57etZ5Cs2hcNUAzqX6cA=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
   <header>
@@ -25,7 +34,7 @@
   <section>
     <h2 class="section-title">Disponibilidad de habitaciones</h2>
     <div style="max-width: var(--max-width); margin: 0 auto;">
-      <p>Seleccione sus fechas de estadía para comprobar la disponibilidad y realizar una solicitud de reserva.</p>
+      <p>Seleccione las fechas de su estadía para comprobar la disponibilidad y realizar una solicitud de reserva.</p>
       <div style="display: flex; flex-wrap: wrap; gap: 1rem; margin-bottom: 1rem;">
         <div>
           <label for="checkIn">Entrada:</label><br>
@@ -102,9 +111,13 @@
       <div class="footer-section">
         <h4>Síguenos</h4>
         <div class="social-icons">
-          <a href="#" aria-label="Facebook"><i class="fab fa-facebook-f"></i></a>
-          <a href="#" aria-label="Instagram"><i class="fab fa-instagram"></i></a>
-          <a href="#" aria-label="Twitter"><i class="fab fa-twitter"></i></a>
+          <a
+            href="https://www.instagram.com/casarubiat/"
+            target="_blank"
+            aria-label="Instagram"
+          >
+            <img src="images/instagram.svg" alt="Instagram Casa Rubia" />
+          </a>
         </div>
       </div>
     </div>
@@ -112,5 +125,15 @@
   </footer>
 
   <script src="script.js"></script>
+  <div class="whatsapp-container">
+    <a
+      href="https://wa.me/573046717881"
+      target="_blank"
+      class="whatsapp-button"
+    >
+      <img src="images/WhatsApp.svg" alt="WhatsApp" />
+      <span class="tooltip">¿En qué te podemos ayudar?</span>
+    </a>
+  </div>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -212,8 +212,8 @@ section {
 
 .room-card img {
   width: 100%;
-  height: 180px;
-  object-fit: cover;
+  height: auto;
+  display: block;
 }
 
 .room-card-body {
@@ -376,6 +376,12 @@ footer .social-icons a {
   font-size: 1.5rem;
   color: #fff;
   transition: color 0.2s ease;
+}
+
+footer .social-icons img {
+  width: 1.5rem;
+  height: 1.5rem;
+  display: block;
 }
 
 footer .social-icons a:hover {
@@ -562,9 +568,6 @@ footer .social-icons a:hover {
   .about-content {
     flex-direction: column;
     text-align: center;
-  }
-  .room-card img {
-    height: 150px;
   }
   .rooms-table th,
   .rooms-table td {


### PR DESCRIPTION
## Summary
- move WhatsApp help button inside `<body>` to ensure proper positioning
- normalize head `<link>` tags in `contact.html` and `rooms.html` for valid markup
- refine Spanish copy and include WhatsApp support button on every page
- let room card images expand to full height so air-conditioned room photos display completely
- replace placeholder social icons with a linked Instagram logo in each page’s footer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689922ab7db4833089722719fe26c8de