### PR TITLE
Add n8n chat widget

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -17,6 +17,10 @@
     referrerpolicy="no-referrer"
   />
   <link rel="stylesheet" href="style.css" />
+  <link
+    href="https://cdn.jsdelivr.net/npm/@n8n/chat/dist/style.css"
+    rel="stylesheet"
+  />
 </head>
 <body>
   <header>
@@ -93,6 +97,13 @@
   </footer>
 
   <script src="script.js"></script>
+  <script type="module">
+    import { createChat } from "https://cdn.jsdelivr.net/npm/@n8n/chat/dist/chat.bundle.es.js";
+
+    createChat({
+      webhookUrl: "http://localhost:5678/webhook/944cade3-de28-4eb7-b347-f534e267e27f/chat",
+    });
+  </script>
   <div class="whatsapp-container">
     <a
       href="https://wa.me/573046717881"

--- a/index.html
+++ b/index.html
@@ -20,6 +20,10 @@
     />
     <!-- Site styles -->
     <link rel="stylesheet" href="style.css" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/@n8n/chat/dist/style.css"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <!-- Header and navigation -->
@@ -239,6 +243,13 @@
 
     <!-- Scripts -->
     <script src="script.js"></script>
+    <script type="module">
+      import { createChat } from "https://cdn.jsdelivr.net/npm/@n8n/chat/dist/chat.bundle.es.js";
+
+      createChat({
+        webhookUrl: "http://localhost:5678/webhook/944cade3-de28-4eb7-b347-f534e267e27f/chat",
+      });
+    </script>
     <!-- BOTÓN WHATSAPP -->
     <div class="whatsapp-container">
       <a

--- a/rooms.html
+++ b/rooms.html
@@ -17,6 +17,10 @@
     referrerpolicy="no-referrer"
   />
   <link rel="stylesheet" href="style.css" />
+  <link
+    href="https://cdn.jsdelivr.net/npm/@n8n/chat/dist/style.css"
+    rel="stylesheet"
+  />
 </head>
 <body>
   <header>
@@ -125,6 +129,13 @@
   </footer>
 
   <script src="script.js"></script>
+  <script type="module">
+    import { createChat } from "https://cdn.jsdelivr.net/npm/@n8n/chat/dist/chat.bundle.es.js";
+
+    createChat({
+      webhookUrl: "http://localhost:5678/webhook/944cade3-de28-4eb7-b347-f534e267e27f/chat",
+    });
+  </script>
   <div class="whatsapp-container">
     <a
       href="https://wa.me/573046717881"


### PR DESCRIPTION
## Summary
- integrate n8n chat widget across site pages

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a8a83aff88330b26d79626127d38b